### PR TITLE
Setting highWaterMark to 16

### DIFF
--- a/csv2.js
+++ b/csv2.js
@@ -6,6 +6,8 @@ function CSV2 (options) {
     return new CSV2(options)
   if (!options)
     options = {}
+  if (!options.highWaterMark)
+    options.highWaterMark = 16
   options.objectMode = true
   Transform.call(this, options)
   this._rawbuf    = ''


### PR DESCRIPTION
Setting highWaterMark to 16 is a good practice to avoid having 16K object waiting to be processed.
