### PR TITLE
Fixing \r line ends bug

### DIFF
--- a/csv2.js
+++ b/csv2.js
@@ -18,7 +18,7 @@ function CSV2 (options) {
 inherits(CSV2, Transform)
 
 CSV2.prototype._processCSV = function (last) {
-  var lines = this._rawbuf.split(/\r?\n/)
+  var lines = this._rawbuf.split(/(\r\n|\n|\r)/)
     , i
 
   for (i = 0; i < lines.length - 1; i++)


### PR DESCRIPTION
Lines are not splitted for some text files composed on MacOS ending with \r only.